### PR TITLE
updates to deal with stashing pages

### DIFF
--- a/.github/workflows/build_mkdocs.yml
+++ b/.github/workflows/build_mkdocs.yml
@@ -45,12 +45,18 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Stash changes
+        run: git stash --include-untracked
+
       - name: Pull latest gh-pages
         run: |
           git fetch origin gh-pages
           git checkout gh-pages
           git pull origin gh-pages
           git checkout -
+
+      - name: Apply stash
+        run: git stash pop
 
       - name: Deploy to GitHub Pages
         run: mkdocs gh-deploy --force


### PR DESCRIPTION
Introduces updates to our CI workflow for handling stashing pages during the deployment process to GitHub Pages. 

### Motivation:
In our current workflow, untracked changes can disrupt the deployment process, leading to potential errors or incomplete deployments. By implementing a stash operation before pulling the latest changes from the `gh-pages` branch, we ensure that any local modifications do not interfere with the deployment process.

### Changes Made:
1. **Stash Changes**: Before pulling the latest `gh-pages`, we stash any local changes, including untracked files. This prevents conflicts and ensures a clean state for the upcoming operations.
2. **Apply Stash**: After updating the branch, we pop the stash to restore any local changes, preserving our intended modifications while still ensuring a smooth deployment.

### Improvements:
These adjustments enhance the reliability of our deployment process by isolating untracked changes, thereby reducing the likelihood of errors during the Git operations. This leads to a more robust and predictable CI/CD pipeline, ultimately improving the quality of our documentation deployments.