### PR TITLE
adding 3.13 testing

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -24,7 +24,7 @@ jobs:
       max-parallel: 10
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.12","3.11", "3.10", "3.9"]
+        python-version: ["3.13","3.12","3.11", "3.10", "3.9"]
     steps:
       - uses: actions/checkout@v4
       - name: Wait for PostgreSQL to become ready

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ Python:
 
 Support Python Versions
 
-![Static Badge](https://img.shields.io/badge/Python-3.12%20%7C%203.11%20%7C%203.10%20%7C%203.9-blue)
+![Static Badge](https://img.shields.io/badge/Python-3.13%20%7C%203.12%20%7C%203.11%20%7C%203.10%20%7C%203.9-blue)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Coverage Status](./coverage-badge.svg?dummy=8484744)](./reports/coverage/index.html)
 [![Tests Status](./tests-badge.svg?dummy=8484744)](./reports/coverage/index.html)


### PR DESCRIPTION
Updates our CI testing configuration to include Python 3.13. By adding this version to our testing matrix, we ensure that our codebase remains compatible with the latest Python releases, allowing us to take advantage of new features, improvements, and optimizations introduced in Python 3.13.

Including Python 3.13 in our testing helps us identify any potential compatibility issues early in the development process, thereby enhancing the project's stability and reliability. This proactive approach also positions our project to be more future-proof by ensuring that we are aligned with the latest advancements in the Python ecosystem.