### PR TITLE
adding raw link to release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,7 +1,7 @@
 # name-template: 'v$RESOLVED_VERSION'
 # tag-template: 'v$RESOLVED_VERSION'
 header: |
-  ![DSG Logo](/images/devsetgo_lib_logo_white_bg.svg)
+  ![DSG Logo](https://raw.githubusercontent.com/devsetgo/devsetgo_lib/refs/heads/main/images/devsetgo_lib_logo_white_bg.svg)
   Drafts your next release notes as pull requests are merged into master.
 version-template: "2023.10.06.$PATCH"
 template: |


### PR DESCRIPTION
### Pull Request Description: Adding Raw Link to Release Drafter

This pull request updates the `release-drafter.yml` configuration to include a raw link for the DSG logo. By changing the logo's reference from a relative path to a raw URL, we ensure that the logo is consistently displayed in the release notes, regardless of the context in which the release drafter is invoked.

**Motivation:**
- **Consistency**: Using a raw link guarantees that the logo will always be accessible and correctly rendered in the draft release notes, eliminating potential issues related to file path resolution.
- **Improved Visibility**: This change enhances the presentation of our release notes, contributing to a more professional appearance and ensuring that branding is consistently represented.

Overall, this enhancement improves the user experience for anyone reviewing the release notes and maintains the integrity of our project's branding.