### PR TITLE
fix: Improve version detection in publish workflow

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -67,13 +67,37 @@ jobs:
       - name: Get release version
         id: get_version
         run: |
-          # Get version from GitHub release tag
-          RAW_VERSION=${GITHUB_REF#refs/tags/}
-          # Remove 'v' prefix if present
-          VERSION=${RAW_VERSION#v}
+          # Debug environment variables
+          echo "GITHUB_REF: $GITHUB_REF"
+          echo "GITHUB_REF_NAME: $GITHUB_REF_NAME"
+          echo "GITHUB_REF_TYPE: $GITHUB_REF_TYPE"
+
+          # Try multiple sources for version detection
+          VERSION=""
+
+          # First try: GitHub release tag
+          if [[ -n "$GITHUB_REF" && "$GITHUB_REF" =~ ^refs/tags/ ]]; then
+            RAW_VERSION=${GITHUB_REF#refs/tags/}
+            VERSION=${RAW_VERSION#v}
+            echo "Found version from GITHUB_REF: $VERSION"
+          elif [[ -n "$GITHUB_REF_NAME" && "$GITHUB_REF_TYPE" == "tag" ]]; then
+            VERSION=${GITHUB_REF_NAME#v}
+            echo "Found version from GITHUB_REF_NAME: $VERSION"
+          fi
+
+          # Second try: Use deploy_docs.py automatic detection
+          if [[ -z "$VERSION" ]]; then
+            echo "No version from GitHub refs, using deploy_docs.py detection"
+            VERSION=$(python3 scripts/deploy_docs.py list 2>/dev/null | head -1 | awk '{print $1}' || echo "")
+            if [[ -z "$VERSION" ]]; then
+              # Extract version from pyproject.toml as fallback
+              VERSION=$(grep -E '^version\s*=' pyproject.toml | sed -E 's/version\s*=\s*["\']([^"'\'']+)["\''].*/\1/' || echo "")
+              echo "Found version from pyproject.toml: $VERSION"
+            fi
+          fi
+
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Raw version from tag: $RAW_VERSION"
-          echo "Cleaned version: $VERSION"
+          echo "Final version: $VERSION"
 
       - name: Prepare documentation files
         run: |
@@ -102,11 +126,22 @@ jobs:
           VERSION="${{ steps.get_version.outputs.version }}"
           echo "Deploying documentation for version: $VERSION"
 
-          # Check if version is valid
+          # Check if version is valid, if not try automatic detection
           if [ -z "$VERSION" ] || [ "$VERSION" = "refs/tags/" ]; then
-            echo "Error: Invalid version detected: '$VERSION'"
-            echo "GITHUB_REF was: $GITHUB_REF"
-            exit 1
+            echo "Version is empty or invalid, trying automatic detection..."
+            # Let deploy_docs.py handle version detection automatically
+            echo "Using deploy_docs.py automatic version detection"
+            if python3 scripts/deploy_docs.py deploy \
+              --aliases latest stable \
+              --title "Latest Release" \
+              --push; then
+              echo "Documentation deployed successfully with automatic version detection"
+              exit 0
+            else
+              echo "Error: Could not deploy with automatic version detection"
+              echo "GITHUB_REF was: $GITHUB_REF"
+              exit 1
+            fi
           fi
 
           # Try to deploy with push first


### PR DESCRIPTION
- Add multiple fallback strategies for version extraction
- Use deploy_docs.py automatic detection when GitHub refs fail
- Add debugging output for troubleshooting version issues
- Prevent workflow failure when GITHUB_REF is empty
- Support manual workflow dispatch and various trigger types

Resolves version detection errors in documentation deployment.