### PR TITLE
fix of publishing

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -91,7 +91,7 @@ jobs:
             VERSION=$(python3 scripts/deploy_docs.py list 2>/dev/null | head -1 | awk '{print $1}' || echo "")
             if [[ -z "$VERSION" ]]; then
               # Extract version from pyproject.toml as fallback
-              VERSION=$(grep -E '^version\s*=' pyproject.toml | sed -E 's/version\s*=\s*["\']([^"'\'']+)["\''].*/\1/' || echo "")
+              VERSION=$(python3 -c "import pathlib, tomllib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text(encoding='utf-8')).get('project', {}).get('version', ''))" || echo "")
               echo "Found version from pyproject.toml: $VERSION"
             fi
           fi


### PR DESCRIPTION
Addresses an issue with the version extraction process during the publishing workflow. The previous method relied on a `grep` command to extract the version from `pyproject.toml`, which could be error-prone and less maintainable.

In this update, we replace the `grep` command with a Python script that uses the `tomllib` module to read the `pyproject.toml` file. This approach ensures a more reliable and robust extraction of the version information, as it directly parses the TOML format rather than relying on string manipulation.

By improving the method of version extraction, we enhance the reliability of our publishing process, reducing the likelihood of errors and ensuring that the correct version is published. This change contributes to a smoother deployment experience and helps maintain the integrity of our release process.