### PR TITLE
docs: add recipe examples for async_database_functions and folder_functions

### DIFF
--- a/docs/examples/database_example.md
+++ b/docs/examples/database_example.md
@@ -1,0 +1,228 @@
+# database_example Example
+
+# Database Example Module
+
+Demonstrates `dsg_lib.async_database_functions`, the async SQLAlchemy toolkit
+made up of four pieces that are normally wired together in this order:
+
+1. `database_config.DBConfig` -- turns a plain config dict into a SQLAlchemy
+   async engine + session factory.
+2. `async_database.AsyncDatabase` -- wraps a `DBConfig` and adds
+   `create_tables()` / `disconnect()` and the shared declarative `Base`.
+3. `base_schema.SchemaBaseSQLite` -- a mixin that gives every model a
+   `pkid`/`date_created`/`date_updated` column for free (dialect-specific
+   siblings exist for Postgres, MySQL, Oracle, MSSQL, Firebird, Sybase, and
+   CockroachDB).
+4. `database_operations.DatabaseOperations` -- the query surface used at
+   runtime: `execute_one` / `execute_many` for writes, `read_query` /
+   `read_one_record` / `read_multi_query` / `count_query` / `paginate_query`
+   for reads, plus introspection (`get_table_names`, `get_columns_details`,
+   `get_primary_keys`).
+
+This example uses an in-memory SQLite database (`sqlite+aiosqlite:///:memory:`)
+so it runs standalone with no external services, but every call shown here
+works unchanged against Postgres/MySQL/MSSQL/Oracle -- only the
+`database_uri` and the `SchemaBase*` mixin change.
+
+## Functions
+
+### `build_database() -> AsyncDatabase`
+Builds the `DBConfig` -> `AsyncDatabase` pair and creates the tables for the
+`User` model defined in this module.
+
+### `insert_users(db_ops, names) -> dict`
+Inserts several rows in one transaction via `execute_many`.
+
+### `read_examples(db_ops) -> dict`
+Runs `read_query`, `read_one_record`, `read_multi_query`, `count_query`, and
+`paginate_query` against the seeded data.
+
+### `update_and_delete(db_ops, user_id) -> dict`
+Runs an `execute_one` UPDATE and an `execute_one` DELETE against a single row.
+
+### `inspect_schema(db_ops) -> dict`
+Runs the introspection helpers: `get_table_names`, `get_columns_details`,
+`get_primary_keys`.
+
+## Usage
+
+Run the module directly to build the database, seed it, exercise every read
+and write method, inspect the schema, and disconnect.
+
+## Example Execution
+
+```bash
+python database_example.py
+```
+## License
+This module is licensed under the MIT License.
+
+```python
+import asyncio
+from typing import Any, Dict, List
+
+from sqlalchemy import Column, String, delete, insert, select, update
+
+from dsg_lib.async_database_functions import (
+    async_database,
+    base_schema,
+    database_config,
+    database_operations,
+)
+from dsg_lib.async_database_functions.database_config import BASE
+
+
+class User(base_schema.SchemaBaseSQLite, BASE):
+    """A minimal model: `pkid`/`date_created`/`date_updated` come from the mixin."""
+
+    __tablename__ = "example_users"
+
+    name = Column(String(100), nullable=False)
+    email = Column(String(100), nullable=True)
+
+    def __repr__(self) -> str:
+        return f"User(name={self.name!r}, email={self.email!r})"
+
+
+async def build_database() -> async_database.AsyncDatabase:
+    """
+    Create the engine/session factory and the `example_users` table.
+
+    Returns:
+        AsyncDatabase: A ready-to-use database wrapper.
+    """
+    config = {
+        "database_uri": "sqlite+aiosqlite:///:memory:?cache=shared",
+        "echo": False,
+        "future": True,
+        "pool_recycle": 3600,
+    }
+    db_config = database_config.DBConfig(config)
+    async_db = async_database.AsyncDatabase(db_config)
+    await async_db.create_tables()
+    return async_db
+
+
+async def insert_users(
+    db_ops: database_operations.DatabaseOperations, names: List[str]
+) -> Dict[str, Any]:
+    """
+    Insert one row per name in a single transaction using `execute_many`.
+
+    Args:
+        db_ops (DatabaseOperations): The operations instance to run queries with.
+        names (List[str]): Names to insert as `User` rows.
+
+    Returns:
+        Dict[str, Any]: Per-row metadata (rowcount, inserted_primary_key) for each insert.
+    """
+    queries = [
+        (insert(User), {"name": name, "email": f"{name.lower()}@example.com"})
+        for name in names
+    ]
+    result = await db_ops.execute_many(queries, return_results=True)
+    return {"insert_metadata": result}
+
+
+async def read_examples(db_ops: database_operations.DatabaseOperations) -> Dict[str, Any]:
+    """
+    Demonstrate every read method against the seeded `example_users` table.
+
+    Args:
+        db_ops (DatabaseOperations): The operations instance to run queries with.
+
+    Returns:
+        Dict[str, Any]: The result of each read method, keyed by method name.
+    """
+    all_users = await db_ops.read_query(select(User).order_by(User.name))
+
+    one_user = await db_ops.read_one_record(select(User).where(User.name == "Ada"))
+
+    multi = await db_ops.read_multi_query(
+        {
+            "names_only": select(User.name).order_by(User.name),
+            "all_columns": select(User).order_by(User.name),
+        }
+    )
+
+    total = await db_ops.count_query(select(User))
+
+    page = await db_ops.paginate_query(select(User).order_by(User.name), page=1, page_size=2)
+
+    return {
+        "read_query": all_users,
+        "read_one_record": one_user,
+        "read_multi_query": multi,
+        "count_query": total,
+        "paginate_query": page,
+    }
+
+
+async def update_and_delete(
+    db_ops: database_operations.DatabaseOperations, name_to_update: str, name_to_delete: str
+) -> Dict[str, Any]:
+    """
+    Update one row and delete another, both via `execute_one`.
+
+    Args:
+        db_ops (DatabaseOperations): The operations instance to run queries with.
+        name_to_update (str): Existing name whose email should be changed.
+        name_to_delete (str): Existing name to remove entirely.
+
+    Returns:
+        Dict[str, Any]: Metadata from the UPDATE and the DELETE.
+    """
+    update_query = (
+        update(User).where(User.name == name_to_update).values(email="updated@example.com")
+    )
+    update_meta = await db_ops.execute_one(update_query, return_metadata=True)
+
+    delete_query = delete(User).where(User.name == name_to_delete)
+    delete_meta = await db_ops.execute_one(delete_query, return_metadata=True)
+
+    return {"update": update_meta, "delete": delete_meta}
+
+
+async def inspect_schema(db_ops: database_operations.DatabaseOperations) -> Dict[str, Any]:
+    """
+    Demonstrate the introspection helpers against the `User` model.
+
+    Args:
+        db_ops (DatabaseOperations): The operations instance to run queries with.
+
+    Returns:
+        Dict[str, Any]: Table names, column details, and primary keys.
+    """
+    return {
+        "table_names": await db_ops.get_table_names(),
+        "columns": await db_ops.get_columns_details(User),
+        "primary_keys": await db_ops.get_primary_keys(User),
+    }
+
+
+async def main() -> None:
+    print("Building database and creating tables...")
+    async_db = await build_database()
+    db_ops = database_operations.DatabaseOperations(async_db)
+
+    print("\nInserting users via execute_many...")
+    print(await insert_users(db_ops, ["Ada", "Grace", "Alan"]))
+
+    print("\nRunning read examples...")
+    for name, result in (await read_examples(db_ops)).items():
+        print(f"  {name}: {result}")
+
+    print("\nUpdating and deleting via execute_one...")
+    print(await update_and_delete(db_ops, name_to_update="Ada", name_to_delete="Alan"))
+
+    print("\nInspecting schema...")
+    for name, result in (await inspect_schema(db_ops)).items():
+        print(f"  {name}: {result}")
+
+    print("\nDisconnecting...")
+    await async_db.disconnect()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```

--- a/docs/examples/folder_example.md
+++ b/docs/examples/folder_example.md
@@ -1,0 +1,142 @@
+# folder_example Example
+
+# Folder Example Module
+
+Demonstrates `dsg_lib.common_functions.folder_functions`: `make_folder`,
+`get_directory_list`, `last_data_files_changed`, and `remove_folder`.
+
+## Functions
+
+### `create_workspace(base_dir: Path) -> Path`
+Creates a new folder under `base_dir` using `make_folder`, and shows the
+`FileExistsError` it raises on a repeat call.
+
+### `list_subfolders(base_dir: Path) -> list`
+Lists the subfolders of `base_dir` using `get_directory_list`.
+
+### `find_last_changed_file(directory: Path)`
+Writes a couple of files into a directory, then finds the most recently
+modified one with `last_data_files_changed`.
+
+### `cleanup_workspace(folder: Path) -> None`
+Removes an empty folder using `remove_folder`, and shows the `OSError` it
+raises when the folder still has files in it.
+
+## Usage
+
+Run the module directly to create a folder, list directories, find the most
+recently changed file, and clean up -- including the two error paths
+(`FileExistsError` from a duplicate `make_folder`, `OSError` from removing a
+non-empty folder).
+
+## Example Execution
+
+```bash
+python folder_example.py
+```
+## License
+This module is licensed under the MIT License.
+
+```python
+import time
+from pathlib import Path
+
+from dsg_lib.common_functions.folder_functions import (
+    get_directory_list,
+    last_data_files_changed,
+    make_folder,
+    remove_folder,
+)
+
+BASE_DIR: Path = Path.cwd() / "data" / "folder_example"
+
+
+def create_workspace(base_dir: Path) -> Path:
+    """
+    Create a new folder under `base_dir`, then show that creating it again
+    raises `FileExistsError`.
+
+    Args:
+        base_dir (Path): The parent directory to create the workspace in.
+
+    Returns:
+        Path: The path to the newly created folder.
+    """
+    base_dir.mkdir(parents=True, exist_ok=True)
+    workspace = base_dir / "workspace"
+
+    if workspace.is_dir():
+        remove_folder(workspace)  # start from a clean state on repeat runs
+
+    make_folder(workspace)
+    print(f"Created folder: {workspace}")
+
+    try:
+        make_folder(workspace)
+    except FileExistsError as e:
+        print(f"Handled error creating a duplicate folder: {e}")
+
+    return workspace
+
+
+def list_subfolders(base_dir: Path) -> list:
+    """
+    List the subfolders of `base_dir`.
+
+    Args:
+        base_dir (Path): The directory to list subfolders of.
+
+    Returns:
+        list: The subfolders of `base_dir`, as returned by `get_directory_list`.
+    """
+    return get_directory_list(str(base_dir))
+
+
+def find_last_changed_file(directory: Path):
+    """
+    Write two files a moment apart, then report the most recently modified one.
+
+    Args:
+        directory (Path): The directory to write files into and inspect.
+
+    Returns:
+        Tuple[datetime, Path]: The modification time and path of the newest file.
+    """
+    (directory / "first.txt").write_text("created first")
+    time.sleep(0.01)
+    (directory / "second.txt").write_text("created second")
+
+    return last_data_files_changed(directory)
+
+
+def cleanup_workspace(folder: Path) -> None:
+    """
+    Remove `folder`, and show that removing a non-empty folder raises `OSError`.
+
+    Args:
+        folder (Path): The folder to remove. Must be empty to succeed.
+    """
+    try:
+        remove_folder(folder)
+    except OSError as e:
+        print(f"Handled error removing a non-empty folder: {e}")
+        for child in folder.iterdir():
+            child.unlink()
+        remove_folder(folder)
+        print(f"Removed folder after clearing its contents: {folder}")
+
+
+if __name__ == "__main__":
+    print("Creating a workspace folder...")
+    workspace_dir = create_workspace(BASE_DIR)
+
+    print("\nListing subfolders...")
+    print(list_subfolders(BASE_DIR))
+
+    print("\nFinding the most recently changed file...")
+    timestamp, newest_file = find_last_changed_file(workspace_dir)
+    print(f"Newest file: {newest_file} (changed at {timestamp})")
+
+    print("\nCleaning up...")
+    cleanup_workspace(workspace_dir)
+```

--- a/examples/database_example.py
+++ b/examples/database_example.py
@@ -1,0 +1,226 @@
+# -*- coding: utf-8 -*-
+"""
+# Database Example Module
+
+Demonstrates `dsg_lib.async_database_functions`, the async SQLAlchemy toolkit
+made up of four pieces that are normally wired together in this order:
+
+1. `database_config.DBConfig` -- turns a plain config dict into a SQLAlchemy
+   async engine + session factory.
+2. `async_database.AsyncDatabase` -- wraps a `DBConfig` and adds
+   `create_tables()` / `disconnect()` and the shared declarative `Base`.
+3. `base_schema.SchemaBaseSQLite` -- a mixin that gives every model a
+   `pkid`/`date_created`/`date_updated` column for free (dialect-specific
+   siblings exist for Postgres, MySQL, Oracle, MSSQL, Firebird, Sybase, and
+   CockroachDB).
+4. `database_operations.DatabaseOperations` -- the query surface used at
+   runtime: `execute_one` / `execute_many` for writes, `read_query` /
+   `read_one_record` / `read_multi_query` / `count_query` / `paginate_query`
+   for reads, plus introspection (`get_table_names`, `get_columns_details`,
+   `get_primary_keys`).
+
+This example uses an in-memory SQLite database (`sqlite+aiosqlite:///:memory:`)
+so it runs standalone with no external services, but every call shown here
+works unchanged against Postgres/MySQL/MSSQL/Oracle -- only the
+`database_uri` and the `SchemaBase*` mixin change.
+
+## Functions
+
+### `build_database() -> AsyncDatabase`
+Builds the `DBConfig` -> `AsyncDatabase` pair and creates the tables for the
+`User` model defined in this module.
+
+### `insert_users(db_ops, names) -> dict`
+Inserts several rows in one transaction via `execute_many`.
+
+### `read_examples(db_ops) -> dict`
+Runs `read_query`, `read_one_record`, `read_multi_query`, `count_query`, and
+`paginate_query` against the seeded data.
+
+### `update_and_delete(db_ops, user_id) -> dict`
+Runs an `execute_one` UPDATE and an `execute_one` DELETE against a single row.
+
+### `inspect_schema(db_ops) -> dict`
+Runs the introspection helpers: `get_table_names`, `get_columns_details`,
+`get_primary_keys`.
+
+## Usage
+
+Run the module directly to build the database, seed it, exercise every read
+and write method, inspect the schema, and disconnect.
+
+## Example Execution
+
+```bash
+python database_example.py
+```
+## License
+This module is licensed under the MIT License.
+"""
+import asyncio
+from typing import Any, Dict, List
+
+from sqlalchemy import Column, String, delete, insert, select, update
+
+from dsg_lib.async_database_functions import (
+    async_database,
+    base_schema,
+    database_config,
+    database_operations,
+)
+from dsg_lib.async_database_functions.database_config import BASE
+
+
+class User(base_schema.SchemaBaseSQLite, BASE):
+    """A minimal model: `pkid`/`date_created`/`date_updated` come from the mixin."""
+
+    __tablename__ = "example_users"
+
+    name = Column(String(100), nullable=False)
+    email = Column(String(100), nullable=True)
+
+    def __repr__(self) -> str:
+        return f"User(name={self.name!r}, email={self.email!r})"
+
+
+async def build_database() -> async_database.AsyncDatabase:
+    """
+    Create the engine/session factory and the `example_users` table.
+
+    Returns:
+        AsyncDatabase: A ready-to-use database wrapper.
+    """
+    config = {
+        "database_uri": "sqlite+aiosqlite:///:memory:?cache=shared",
+        "echo": False,
+        "future": True,
+        "pool_recycle": 3600,
+    }
+    db_config = database_config.DBConfig(config)
+    async_db = async_database.AsyncDatabase(db_config)
+    await async_db.create_tables()
+    return async_db
+
+
+async def insert_users(
+    db_ops: database_operations.DatabaseOperations, names: List[str]
+) -> Dict[str, Any]:
+    """
+    Insert one row per name in a single transaction using `execute_many`.
+
+    Args:
+        db_ops (DatabaseOperations): The operations instance to run queries with.
+        names (List[str]): Names to insert as `User` rows.
+
+    Returns:
+        Dict[str, Any]: Per-row metadata (rowcount, inserted_primary_key) for each insert.
+    """
+    queries = [
+        (insert(User), {"name": name, "email": f"{name.lower()}@example.com"})
+        for name in names
+    ]
+    result = await db_ops.execute_many(queries, return_results=True)
+    return {"insert_metadata": result}
+
+
+async def read_examples(db_ops: database_operations.DatabaseOperations) -> Dict[str, Any]:
+    """
+    Demonstrate every read method against the seeded `example_users` table.
+
+    Args:
+        db_ops (DatabaseOperations): The operations instance to run queries with.
+
+    Returns:
+        Dict[str, Any]: The result of each read method, keyed by method name.
+    """
+    all_users = await db_ops.read_query(select(User).order_by(User.name))
+
+    one_user = await db_ops.read_one_record(select(User).where(User.name == "Ada"))
+
+    multi = await db_ops.read_multi_query(
+        {
+            "names_only": select(User.name).order_by(User.name),
+            "all_columns": select(User).order_by(User.name),
+        }
+    )
+
+    total = await db_ops.count_query(select(User))
+
+    page = await db_ops.paginate_query(select(User).order_by(User.name), page=1, page_size=2)
+
+    return {
+        "read_query": all_users,
+        "read_one_record": one_user,
+        "read_multi_query": multi,
+        "count_query": total,
+        "paginate_query": page,
+    }
+
+
+async def update_and_delete(
+    db_ops: database_operations.DatabaseOperations, name_to_update: str, name_to_delete: str
+) -> Dict[str, Any]:
+    """
+    Update one row and delete another, both via `execute_one`.
+
+    Args:
+        db_ops (DatabaseOperations): The operations instance to run queries with.
+        name_to_update (str): Existing name whose email should be changed.
+        name_to_delete (str): Existing name to remove entirely.
+
+    Returns:
+        Dict[str, Any]: Metadata from the UPDATE and the DELETE.
+    """
+    update_query = (
+        update(User).where(User.name == name_to_update).values(email="updated@example.com")
+    )
+    update_meta = await db_ops.execute_one(update_query, return_metadata=True)
+
+    delete_query = delete(User).where(User.name == name_to_delete)
+    delete_meta = await db_ops.execute_one(delete_query, return_metadata=True)
+
+    return {"update": update_meta, "delete": delete_meta}
+
+
+async def inspect_schema(db_ops: database_operations.DatabaseOperations) -> Dict[str, Any]:
+    """
+    Demonstrate the introspection helpers against the `User` model.
+
+    Args:
+        db_ops (DatabaseOperations): The operations instance to run queries with.
+
+    Returns:
+        Dict[str, Any]: Table names, column details, and primary keys.
+    """
+    return {
+        "table_names": await db_ops.get_table_names(),
+        "columns": await db_ops.get_columns_details(User),
+        "primary_keys": await db_ops.get_primary_keys(User),
+    }
+
+
+async def main() -> None:
+    print("Building database and creating tables...")
+    async_db = await build_database()
+    db_ops = database_operations.DatabaseOperations(async_db)
+
+    print("\nInserting users via execute_many...")
+    print(await insert_users(db_ops, ["Ada", "Grace", "Alan"]))
+
+    print("\nRunning read examples...")
+    for name, result in (await read_examples(db_ops)).items():
+        print(f"  {name}: {result}")
+
+    print("\nUpdating and deleting via execute_one...")
+    print(await update_and_delete(db_ops, name_to_update="Ada", name_to_delete="Alan"))
+
+    print("\nInspecting schema...")
+    for name, result in (await inspect_schema(db_ops)).items():
+        print(f"  {name}: {result}")
+
+    print("\nDisconnecting...")
+    await async_db.disconnect()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/folder_example.py
+++ b/examples/folder_example.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+"""
+# Folder Example Module
+
+Demonstrates `dsg_lib.common_functions.folder_functions`: `make_folder`,
+`get_directory_list`, `last_data_files_changed`, and `remove_folder`.
+
+## Functions
+
+### `create_workspace(base_dir: Path) -> Path`
+Creates a new folder under `base_dir` using `make_folder`, and shows the
+`FileExistsError` it raises on a repeat call.
+
+### `list_subfolders(base_dir: Path) -> list`
+Lists the subfolders of `base_dir` using `get_directory_list`.
+
+### `find_last_changed_file(directory: Path)`
+Writes a couple of files into a directory, then finds the most recently
+modified one with `last_data_files_changed`.
+
+### `cleanup_workspace(folder: Path) -> None`
+Removes an empty folder using `remove_folder`, and shows the `OSError` it
+raises when the folder still has files in it.
+
+## Usage
+
+Run the module directly to create a folder, list directories, find the most
+recently changed file, and clean up -- including the two error paths
+(`FileExistsError` from a duplicate `make_folder`, `OSError` from removing a
+non-empty folder).
+
+## Example Execution
+
+```bash
+python folder_example.py
+```
+## License
+This module is licensed under the MIT License.
+"""
+import time
+from pathlib import Path
+
+from dsg_lib.common_functions.folder_functions import (
+    get_directory_list,
+    last_data_files_changed,
+    make_folder,
+    remove_folder,
+)
+
+BASE_DIR: Path = Path.cwd() / "data" / "folder_example"
+
+
+def create_workspace(base_dir: Path) -> Path:
+    """
+    Create a new folder under `base_dir`, then show that creating it again
+    raises `FileExistsError`.
+
+    Args:
+        base_dir (Path): The parent directory to create the workspace in.
+
+    Returns:
+        Path: The path to the newly created folder.
+    """
+    base_dir.mkdir(parents=True, exist_ok=True)
+    workspace = base_dir / "workspace"
+
+    if workspace.is_dir():
+        remove_folder(workspace)  # start from a clean state on repeat runs
+
+    make_folder(workspace)
+    print(f"Created folder: {workspace}")
+
+    try:
+        make_folder(workspace)
+    except FileExistsError as e:
+        print(f"Handled error creating a duplicate folder: {e}")
+
+    return workspace
+
+
+def list_subfolders(base_dir: Path) -> list:
+    """
+    List the subfolders of `base_dir`.
+
+    Args:
+        base_dir (Path): The directory to list subfolders of.
+
+    Returns:
+        list: The subfolders of `base_dir`, as returned by `get_directory_list`.
+    """
+    return get_directory_list(str(base_dir))
+
+
+def find_last_changed_file(directory: Path):
+    """
+    Write two files a moment apart, then report the most recently modified one.
+
+    Args:
+        directory (Path): The directory to write files into and inspect.
+
+    Returns:
+        Tuple[datetime, Path]: The modification time and path of the newest file.
+    """
+    (directory / "first.txt").write_text("created first")
+    time.sleep(0.01)
+    (directory / "second.txt").write_text("created second")
+
+    return last_data_files_changed(directory)
+
+
+def cleanup_workspace(folder: Path) -> None:
+    """
+    Remove `folder`, and show that removing a non-empty folder raises `OSError`.
+
+    Args:
+        folder (Path): The folder to remove. Must be empty to succeed.
+    """
+    try:
+        remove_folder(folder)
+    except OSError as e:
+        print(f"Handled error removing a non-empty folder: {e}")
+        for child in folder.iterdir():
+            child.unlink()
+        remove_folder(folder)
+        print(f"Removed folder after clearing its contents: {folder}")
+
+
+if __name__ == "__main__":
+    print("Creating a workspace folder...")
+    workspace_dir = create_workspace(BASE_DIR)
+
+    print("\nListing subfolders...")
+    print(list_subfolders(BASE_DIR))
+
+    print("\nFinding the most recently changed file...")
+    timestamp, newest_file = find_last_changed_file(workspace_dir)
+    print(f"Newest file: {newest_file} (changed at {timestamp})")
+
+    print("\nCleaning up...")
+    cleanup_workspace(workspace_dir)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
       - log_example: 'examples/log_example.md'
       - cal_example: 'examples/cal_example.md'
       - pattern_example: 'examples/pattern_example.md'
+      - database_example: 'examples/database_example.md'
       - validate_emails: 'examples/validate_emails.md'
       - csv_example_with_timer: 'examples/csv_example_with_timer.md'
       - fastapi_example: 'examples/fastapi_example.md'
@@ -47,6 +48,7 @@ nav:
       - text_example: 'examples/text_example.md'
       - async_file_example: 'examples/async_file_example.md'
       - file_monitor: 'examples/file_monitor.md'
+      - folder_example: 'examples/folder_example.md'
 
     - Documentation:
       - Versioning: 'versioning.md'


### PR DESCRIPTION
Every other library capability already had a runnable recipe under examples/; async_database_functions (DBConfig, AsyncDatabase, SchemaBase mixins, DatabaseOperations CRUD/read/paginate/introspect) and folder_functions (make_folder, get_directory_list, last_data_files_changed, remove_folder) were the only gaps. Docs and mkdocs nav regenerated via scripts/update_docs.py.